### PR TITLE
security: add minimumReleaseAge (7d)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 10080


### PR DESCRIPTION
Adds `minimumReleaseAge: 10080` (7 days) to `pnpm-workspace.yaml`.

**Context:** The [axios npm compromise](https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan) (Mar 30, 2026) injected a RAT via a postinstall script in a fake dependency. The malicious versions were published and removed within hours.

`minimumReleaseAge` prevents pnpm from installing any package version that was published less than 7 days ago, which would have blocked this attack.

Ref: https://pnpm.io/settings#minimumreleaseage