### PR TITLE
ci: restore Vite+ release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@45e5c098f1095cc6b65fd92534603e7be70386c1 # v1
         with:
           node-version-file: ".node-version"
           cache: true
@@ -47,12 +47,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@45e5c098f1095cc6b65fd92534603e7be70386c1 # v1
         with:
           node-version-file: ".node-version"
           cache: true
@@ -73,9 +73,7 @@ jobs:
     timeout-minutes: 20
     environment: release
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
 
     steps:
       - name: Create release bot token
@@ -93,16 +91,14 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.release-bot.outputs.token }}
 
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - name: Set up Vite+
+        uses: voidzero-dev/setup-vp@45e5c098f1095cc6b65fd92534603e7be70386c1 # v1
         with:
           node-version-file: ".node-version"
-
-      - name: Enable Corepack
-        run: corepack enable
+          cache: true
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: vp install
 
       - name: Release package
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 
 - [Overview](./README.md)
 - [Contributing](./CONTRIBUTING.md)
+- [Distribution](./docs/DISTRIBUTION.md)
 - [Security](./SECURITY.md)
 
 ## Commands

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,11 +33,7 @@ That command packs the repo, installs the tarball into a temp project, type-chec
 
 ## Release Publishing
 
-GitHub Actions publishes from `main` through the protected `release` Environment.
-
-Keep `NPM_TOKEN`, `PUTIO_RELEASE_BOT_APP_ID`, and `PUTIO_RELEASE_BOT_PRIVATE_KEY` in that Environment with required reviewers and prevent self-review enabled, not as plain repository secrets. Pull request checks stay secretless and only run verify jobs.
-
-Release GitHub writes use `putio-release-bot` for version sync commits, `v*` tags, GitHub Releases, and npm release notes. Trusted put.io team members may push directly to `main`, but repository rules should block outsiders, force-pushes, and branch deletes where GitHub plan support allows.
+See [Distribution](./docs/DISTRIBUTION.md) for release automation, credentials, and npm publishing.
 
 ## Development Notes
 

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -4,7 +4,7 @@
 
 Every merge to `main` should already be releasable.
 
-GitHub Actions owns npm publishing and GitHub release notes. The pipeline runs the repo's VitePlus commands before publishing:
+GitHub Actions owns npm publishing and GitHub release notes. The pipeline runs the repo's Vite+ commands before publishing:
 
 1. `vp install`
 2. `vp run verify`

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,0 +1,37 @@
+# Distribution
+
+## Delivery Model
+
+Every merge to `main` should already be releasable.
+
+GitHub Actions owns npm publishing and GitHub release notes. The pipeline runs the repo's VitePlus commands before publishing:
+
+1. `vp install`
+2. `vp run verify`
+3. `vp run test:consumer`
+4. `semantic-release`
+
+The workflow uses `.releaserc.json` as the release source of truth.
+
+## Release Environment
+
+Release jobs declare the protected GitHub Environment named `release`.
+
+Environment entries:
+
+- secrets: `NPM_TOKEN`, `PUTIO_RELEASE_BOT_PRIVATE_KEY`
+- variables: `PUTIO_RELEASE_BOT_APP_ID`
+- approval: none; releases are continuous after the `main` gate passes
+- refs: release branch/tag policy constrains what can publish
+
+Release GitHub writes use `putio-release-bot` for version sync commits, `v*` tags, GitHub Releases, and release notes.
+
+## Local Checks
+
+Before changing distribution wiring, validate the repo-local guardrails the workflow depends on:
+
+```bash
+vp install
+vp run verify
+vp run test:consumer
+```


### PR DESCRIPTION
## Summary

## Changed
- Restores VitePlus setup and `vp` commands in release workflow
- Pins verify-path checkout/setup actions and keeps release writes on `putio-release-bot`
- Reduces default release-job `GITHUB_TOKEN` permissions to read-only
- Moves release/publishing detail into `docs/DISTRIBUTION.md` and leaves `CONTRIBUTING.md` as navigation

## Risks
- Release job depends on the pinned `setup-vp` action SHA continuing to resolve to the expected v1 implementation

## Verification
- actionlint .github/workflows/*.yml
- git diff --check

## Complexity
- Reduced: workflow follows the repo VitePlus contract again